### PR TITLE
vendor: set adaptive icon mask to circle

### DIFF
--- a/overlay/common/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/common/frameworks/base/core/res/res/values/config.xml
@@ -81,4 +81,7 @@
     <!-- Flag indicating which package name can access the persistent data partition -->
     <string name="config_persistentDataPackageName" translatable="false">com.google.android.gms</string>
 
+   <!-- Set icon mask to circle -->
+   <string name="config_icon_mask" translatable="false">"M50 0A50 50,0,1,1,50 100A50 50,0,1,1,50 0"</string>
+
 </resources>


### PR DESCRIPTION
For the new icon set we'll be defaulting to a circular
mask that better suits our brand

Change-Id: Id221e7b0d07751929658862d4b1ea91412e93555
Signed-off-by: Joey <joey@lineageos.org>