### PR TITLE
config/common: Clean up debug packages

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -168,16 +168,11 @@ PRODUCT_PACKAGES += \
     bash \
     bzip2 \
     curl \
-    gdbserver \
     htop \
     lib7z \
     libsepol \
-    micro_bench \
-    oprofiled \
     pigz \
     powertop \
-    sqlite3 \
-    strace \
     unrar \
     unzip \
     vim \
@@ -228,12 +223,14 @@ PRODUCT_SYSTEM_DEFAULT_PROPERTIES += \
     media.recorder.show_manufacturer_and_model=true
 
 # These packages are excluded from user builds
-ifneq ($(TARGET_BUILD_VARIANT),user)
-PRODUCT_PACKAGES += \
+PRODUCT_PACKAGES_DEBUG += \
+    micro_bench \
     procmem \
-    procrank
+    procrank \
+    strace
 
 # Conditionally build in su
+ifneq ($(TARGET_BUILD_VARIANT),user)
 ifeq ($(WITH_SU),true)
 PRODUCT_PACKAGES += \
     su


### PR DESCRIPTION
 * Include all debug packages via PRODUCT_PACKAGES_DEBUG.

 * Remove oprofiled and sqlite3 from the list, because the former
   no longer exists and the latter is already part of
   build/target/product/core_base.mk. Also remove gdbserver, since
   it's already built by default.

Change-Id: Icde54061cd5a85d381b756364287344c3d216957